### PR TITLE
Lower heading levels to follow document outline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ Then run `vagrant provision` to instruct Chassis to download and install the new
 Ensure you have a Chassis instance set up locally already.
 
 ```
-# In your Chassis dir:
+#### In your Chassis dir:
 cd extensions
 
-# Grab the extension
+#### Grab the extension
 git clone --recursive https://github.com/Chassis/phpunit.git phpunit
 
-# Reprovision
+#### Reprovision
 cd ..
 vagrant provision
 ```
 
-# Usage
+## Usage
 ```
 vagrant ssh
 cd /vagrant/content/{plugins|themes}/yourdirectory


### PR DESCRIPTION
There were a bunch of top level headings in the readme, this lowers them to follow the document outline.