### PR TITLE
Revert "Add unless parameter"

### DIFF
--- a/modules/phpunit/manifests/init.pp
+++ b/modules/phpunit/manifests/init.pp
@@ -16,25 +16,21 @@ class phpunit (
 		file { $install_path:
 			ensure => directory,
 		}
+
 		if ( ! empty( $config[phpunit] ) and ! empty( $config[phpunit][version] ) ) {
 			$phpunit_repo_url = "https://phar.phpunit.de/phpunit-${config[phpunit][version]}.phar"
-			$phpunit_version = $config[phpunit][version]
-		} elsif versioncmp( $config[php], 5.6 ) == 0 {
+		} elsif versioncmp( $config[php], '5.6' ) == 0 {
 			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-4.8.phar'
-			$phpunit_version = 4.8
 		} elsif versioncmp( $config[php], '7.0' ) == 0 {
 			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-6.5.phar'
-			$phpunit_version = 6.5
 		} else {
 			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-7.5.phar'
-			$phpunit_version = 7.5
 		}
 
 		# Download phpunit
 		exec { 'phpunit download':
 			command => "/usr/bin/curl -o ${install_path}/phpunit.phar -L ${phpunit_repo_url}",
-			require => [ Package[ 'curl' ], File[ $install_path ] ],
-			unless  => "/usr/bin/phpunit phpunit --version | grep 'PHPUnit '${phpunit_version}"
+			require => [ Package[ 'curl' ], File[ $install_path ] ]
 		}
 
 		# Ensure we can run phpunit
@@ -48,7 +44,7 @@ class phpunit (
 		file { '/usr/bin/phpunit':
 			ensure  => link,
 			target  => "${install_path}/phpunit.phar",
-			require => Exec[ 'phpunit download' ]
+			require => File[ "${install_path}/phpunit.phar" ],
 		}
 	} else {
 		file { $install_path:


### PR DESCRIPTION
Reverts Chassis/phpunit#10

The `unless` parameter is causing recursion in which `/usr/bin/phpunit` must be available to create `/usr/bin/phpunit`. On first ups, this is not possible.

I think what's needed is the puppet equivalent of

```php
if ( ! file_exists( phpunit )  || ( /* version incorrect */ ) ) 
   install( phpunit )
```